### PR TITLE
nginx improvements

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -3,8 +3,8 @@
   <modelVersion>4.0.0</modelVersion>
   <parent>
     <groupId>org.cloudhoist</groupId>
-    <artifactId>pallet-crates</artifactId>
-    <version>0.5.1-SNAPSHOT</version>
+    <artifactId>pallet-crate-pom</artifactId>
+    <version>0.6.1-SNAPSHOT</version>
     <relativePath>..</relativePath>
   </parent>
   <artifactId>nginx</artifactId>
@@ -14,11 +14,6 @@
     <dependency>
       <groupId>org.cloudhoist</groupId>
       <artifactId>rubygems</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>org.cloudhoist</groupId>
-      <artifactId>pallet-crates-test</artifactId>
-      <scope>test</scope>
     </dependency>
   </dependencies>
   <!-- make sure we can find the parent pom -->

--- a/pom.xml
+++ b/pom.xml
@@ -8,7 +8,7 @@
     <relativePath>..</relativePath>
   </parent>
   <artifactId>nginx</artifactId>
-  <version>0.5.1-SNAPSHOT</version>
+  <version>0.6.0-SNAPSHOT</version>
 
   <dependencies>
     <dependency>
@@ -21,4 +21,11 @@
       <scope>test</scope>
     </dependency>
   </dependencies>
+  <!-- make sure we can find the parent pom -->
+  <repositories>
+    <repository>
+      <id>sonatype</id>
+      <url>http://oss.sonatype.org/content/repositories/releases</url>
+    </repository>
+  </repositories>
 </project>

--- a/resources/crate/nginx/location
+++ b/resources/crate/nginx/location
@@ -2,6 +2,7 @@ location ~{location} {
   ~(when root (format "root %s;" root))
   index  ~(apply str (interpose " " index));
   ~(when proxy_pass (format "proxy_pass %s;" proxy_pass))
+  ~(when proxy_headers (clojure.string/join "\n" (map (fn [[k v]] (format "proxy_set_header %s %s;" k v)) proxy_headers)))
   ~(when passenger-enabled (format "passenger_enabled %s;" passenger-enabled))
   ~(when rails-env (format "rails_env %s;" rails-env))
 }

--- a/src/pallet/crate/nginx.clj
+++ b/src/pallet/crate/nginx.clj
@@ -235,7 +235,9 @@
                             (reduce
                              merge {:locations locations}
                              [nginx-default-site
-                              (dissoc options :locations)])))))]
+                              (dissoc options :locations)]))
+                  :no-versioning true
+                  :md5 nil)))]
     (->
      session
      (directory/directory (format "%s/sites-available" nginx-conf-dir))

--- a/src/pallet/crate/nginx.clj
+++ b/src/pallet/crate/nginx.clj
@@ -81,6 +81,7 @@
       :root nil
       :index ["index.html" "index.htm"]
       :proxy_pass nil
+      :proxy_headers nil
       :rails-env nil
       :passenger-enabled nil})
 

--- a/src/pallet/crate/nginx.clj
+++ b/src/pallet/crate/nginx.clj
@@ -26,7 +26,7 @@
      {"0.7.65" "abc4f76af450eedeb063158bd963feaa"})
 
 (defn ftp-path [version]
-  (format "http://sysoev.ru/nginx/nginx-%s.tar.gz" version))
+  (format "http://nginx.org/download/nginx-%s.tar.gz" version))
 
 (def nginx-conf-dir "/etc/nginx")
 (def nginx-install-dir "/opt/nginx")
@@ -213,7 +213,7 @@
 :listen        -- address to listen on
 :server_name   -- name
 :locations     -- locations (a seq of maps, with keys :location, :root
-                  :index, :proxy_pass :passenger-enabled :rails-env)"
+                  :index, :proxy_pass, :proxy_headers ( a map of headers to their values) :passenger-enabled :rails-env)"
   [session name & {:keys [locations action] :or {action :enable} :as options}]
   (let [available (format "%s/sites-available/%s" nginx-conf-dir name)
         enabled (format "%s/sites-enabled/%s" nginx-conf-dir name)

--- a/test/pallet/crate/nginx_test.clj
+++ b/test/pallet/crate/nginx_test.clj
@@ -17,7 +17,7 @@
            (directory/directory "/etc/nginx/sites-enabled")
            (remote-file/remote-file
             "/etc/nginx/sites-enabled/mysite"
-            :content "server {\n  listen       80;\n  server_name  localhost;\n\n  access_log  /var/log/nginx/access.log;\n\nlocation / {\n  root /some/path;\n  index  index.html index.htm;\n  \n  \n  \n}\n\nlocation /a {\n  \n  index  index.html index.htm;\n  proxy_pass localhost:8080;\n  \n  \n}\n\n}\n")
+            :content "server {\n  listen       80;\n  server_name  localhost;\n\n  access_log  /var/log/nginx/access.log;\n\nlocation / {\n  root /some/path;\n  index  index.html index.htm;\n  \n  \n  \n  \n}\n\nlocation /a {\n  \n  index  index.html index.htm;\n  proxy_pass localhost:8080;\n  proxy_set_header X-Real-IP \\$remote_addr;\nproxy_set_header X-Forwarded-For \\$proxy_add_x_forwarded_for;\nproxy_set_header Host \\$http_host;\n  \n  \n}\n\n}\n")
            (file/file
             "/etc/nginx/sites-available/mysite" :action :delete :force true)))
          (first
@@ -26,4 +26,7 @@
            (site "mysite"
                  :locations [{:location "/" :root "/some/path"}
                              {:location "/a"
-                              :proxy_pass "localhost:8080"}]))))))
+                              :proxy_pass "localhost:8080"
+                              :proxy_headers {"X-Real-IP" "\\$remote_addr"
+                                              "X-Forwarded-For" "\\$proxy_add_x_forwarded_for"
+                                              "Host" "\\$http_host"}}]))))))


### PR DESCRIPTION
These commits add support for setting proxy headers in the nginx site, and disable versioning on the sites enabled, because nginx was attempting to load the .md5 and version files.
