### PR TITLE
Fixes needed to get nginx to build

### DIFF
--- a/resources/crate/nginx/nginx.conf
+++ b/resources/crate/nginx/nginx.conf
@@ -29,5 +29,5 @@ http {
     gzip_types ~(apply str (interpose " " gzip_types));
 
     include /etc/nginx/conf.d/*.conf;
-    include /etc/nginx/sites-enabled/*;
+    include /etc/nginx/sites-enabled/*.conf;
 }

--- a/src/pallet/crate/nginx.clj
+++ b/src/pallet/crate/nginx.clj
@@ -20,7 +20,7 @@
   (:use pallet.thread-expr))
 
 (def src-packages
-     ["libpcre3" "libpcre3-dev" "libssl" "libssl-dev"])
+     ["libpcre3" "libpcre3-dev" "libssl" "libssl-dev" "build-essential"])
 
 (def nginx-md5s
      {"0.7.65" "abc4f76af450eedeb063158bd963feaa"})

--- a/src/pallet/crate/nginx.clj
+++ b/src/pallet/crate/nginx.clj
@@ -215,8 +215,8 @@
 :locations     -- locations (a seq of maps, with keys :location, :root
                   :index, :proxy_pass :passenger-enabled :rails-env)"
   [session name & {:keys [locations action] :or {action :enable} :as options}]
-  (let [available (format "%s/sites-available/%s" nginx-conf-dir name)
-        enabled (format "%s/sites-enabled/%s" nginx-conf-dir name)
+  (let [available (format "%s/sites-available/%s.conf" nginx-conf-dir name)
+        enabled (format "%s/sites-enabled/%s.conf" nginx-conf-dir name)
         site (fn [session filename]
                (let [locations (string/join
                                 \newline

--- a/src/pallet/crate/nginx.clj
+++ b/src/pallet/crate/nginx.clj
@@ -95,7 +95,7 @@
         modules (options :version)
         basename (str "nginx-" version)
         tarfile (str basename ".tar.gz")
-        tarpath (str (stevedore/script (tmp-dir)) "/" tarfile)
+        tarpath (str "/tmp/" tarfile)
         options (if (:passenger options)
                   (update-in
                    options [:add-modules]

--- a/src/pallet/crate/nginx.clj
+++ b/src/pallet/crate/nginx.clj
@@ -194,7 +194,6 @@
     (format "%s/mime.types.default" nginx-conf-dir)
     :action :delete)))
 
-
 (defn init
   "Creates a nginx init script."
   [session & {:as options}]
@@ -206,7 +205,14 @@
               (template/find-template nginx-init-script session))
     :literal true)
    (if-not-> (:no-enable options)
-     (service/service "nginx" :action :enable))))
+             (service/service "nginx" :action :enable))))
+
+(defn control
+  "Control (start, stop, restart) the nginx service"
+  [session action]
+  (->
+   session
+   (service/service "nginx" :action action)))
 
 (defn site
   "Enable or disable a site.  Options:

--- a/src/pallet/crate/nginx.clj
+++ b/src/pallet/crate/nginx.clj
@@ -23,10 +23,11 @@
      ["libpcre3" "libpcre3-dev" "libssl" "libssl-dev" "build-essential"])
 
 (def nginx-md5s
-     {"0.7.65" "abc4f76af450eedeb063158bd963feaa"})
+  {"0.7.65" "abc4f76af450eedeb063158bd963feaa"
+   "1.1.18" "82f4b4b1fba68f5f83cc2c641fb6c4c5"})
 
 (defn ftp-path [version]
-  (format "http://sysoev.ru/nginx/nginx-%s.tar.gz" version))
+  (format "http://nginx.org/download/nginx-%s.tar.gz" version))
 
 (def nginx-conf-dir "/etc/nginx")
 (def nginx-install-dir "/opt/nginx")
@@ -45,7 +46,7 @@
 (def nginx-mime-conf "crate/nginx/mime.types")
 
 (def nginx-defaults
-     {:version "0.7.65"
+     {:version "1.1.18"
       :modules [:http_ssl_module :http_gzip_static_module]})
 
 (def nginx-default-conf

--- a/test/pallet/crate/nginx_test.clj
+++ b/test/pallet/crate/nginx_test.clj
@@ -16,10 +16,10 @@
            (directory/directory "/etc/nginx/sites-available")
            (directory/directory "/etc/nginx/sites-enabled")
            (remote-file/remote-file
-            "/etc/nginx/sites-enabled/mysite"
+            "/etc/nginx/sites-enabled/mysite.conf"
             :content "server {\n  listen       80;\n  server_name  localhost;\n\n  access_log  /var/log/nginx/access.log;\n\nlocation / {\n  root /some/path;\n  index  index.html index.htm;\n  \n  \n  \n}\n\nlocation /a {\n  \n  index  index.html index.htm;\n  proxy_pass localhost:8080;\n  \n  \n}\n\n}\n")
            (file/file
-            "/etc/nginx/sites-available/mysite" :action :delete :force true)))
+            "/etc/nginx/sites-available/mysite.conf" :action :delete :force true)))
          (first
           (build-actions/build-actions
            {:server {:group-name :n :image {:os-family :ubuntu}}}


### PR DESCRIPTION
1. The tarball tmp dir needed to be hardcoded to pull the nginx source. See https://github.com/pallet/nginx-crate/issues/2
2. Added the 'build-essential' package so gcc/make will actually get installed before attempting to build nginx.
3. Make sites-enabled and sites-available use *.conf suffixes to avoid versioning and md5 conflicts
