### PR TITLE
Adding proxy-set-header directives to proxy-pass.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -12,7 +12,7 @@
     <url>https://github.com/pallet/nginx-crate</url>
   </scm>
   <artifactId>nginx</artifactId>
-  <version>0.7.0-SNAPSHOT</version>
+  <version>0.7.1-SNAPSHOT</version>
 
   <dependencies>
     <dependency>

--- a/resources/crate/nginx/location
+++ b/resources/crate/nginx/location
@@ -2,6 +2,10 @@ location ~{location} {
   ~(when root (format "root %s;" root))
   index  ~(apply str (interpose " " index));
   ~(when proxy_pass (format "proxy_pass %s;" proxy_pass))
+~(when (not (or (empty? proxy_pass) (empty? proxy_set_headers)))
+  (apply str (map
+                (fn [[n v]] (format "  proxy_set_header %s %s;\n" (name n) (name v)))
+                proxy_set_headers)))
   ~(when passenger-enabled (format "passenger_enabled %s;" passenger-enabled))
   ~(when rails-env (format "rails_env %s;" rails-env))
 }

--- a/src/pallet/crate/nginx.clj
+++ b/src/pallet/crate/nginx.clj
@@ -83,6 +83,7 @@
       :root nil
       :index ["index.html" "index.htm"]
       :proxy_pass nil
+      :proxy_set_headers nil
       :rails-env nil
       :passenger-enabled nil})
 
@@ -214,8 +215,10 @@
   "Enable or disable a site.  Options:
 :listen        -- address to listen on
 :server_name   -- name
-:locations     -- locations (a seq of maps, with keys :location, :root
-                  :index, :proxy_pass :passenger-enabled :rails-env)"
+:locations     -- locations (a seq of maps, with keys :location (the apparent path), :root (the actual path),
+                  :index (name of the index file), :proxy_pass (url to pass to),
+                  :proxy_set_headers (map of header name to header value, either symbols or strings),
+                  :passenger-enabled :rails-env)"
   [session name & {:keys [locations action] :or {action :enable} :as options}]
   (let [available (format "%s/sites-available/%s" nginx-conf-dir name)
         enabled (format "%s/sites-enabled/%s" nginx-conf-dir name)

--- a/test/pallet/crate/nginx_test.clj
+++ b/test/pallet/crate/nginx_test.clj
@@ -17,7 +17,7 @@
            (directory/directory "/etc/nginx/sites-enabled")
            (remote-file/remote-file
             "/etc/nginx/sites-enabled/mysite"
-            :content "server {\n  listen       80;\n  server_name  localhost;\n\n  access_log  /var/log/nginx/access.log;\n\nlocation / {\n  root /some/path;\n  index  index.html index.htm;\n  \n  \n  \n}\n\nlocation /a {\n  \n  index  index.html index.htm;\n  proxy_pass localhost:8080;\n  \n  \n}\n\n}\n")
+            :content "server {\n  listen       80;\n  server_name  localhost;\n\n  access_log  /var/log/nginx/access.log;\n\nlocation / {\n  root /some/path;\n  index  index.html index.htm;\n  \n\n  \n  \n}\n\nlocation /a {\n  \n  index  index.html index.htm;\n  proxy_pass localhost:8080;\n\n  \n  \n}\n\nlocation /b {\n  \n  index  index.html index.htm;\n  proxy_pass localhost:9090;\n  proxy_set_header X-Real-IP $remote_addr;\n\n  \n  \n}\n\n}\n")
            (file/file
             "/etc/nginx/sites-available/mysite" :action :delete :force true)))
          (first
@@ -26,4 +26,7 @@
            (site "mysite"
                  :locations [{:location "/" :root "/some/path"}
                              {:location "/a"
-                              :proxy_pass "localhost:8080"}]))))))
+                              :proxy_pass "localhost:8080"}
+                             {:location "/b"
+                              :proxy_pass "localhost:9090"
+                              :proxy_set_headers {:X-Real-IP "$remote_addr"}}]))))))


### PR DESCRIPTION
This is a PR to add `proxy_set_header` to the location template and supporting generator code. `proxy_pass` is significantly less useful without this feature. Tests pass.
